### PR TITLE
Fix missing InputOption::VALUE_NEGATABLE for composer 2.0

### DIFF
--- a/src/Commands/LinkCommand.php
+++ b/src/Commands/LinkCommand.php
@@ -32,7 +32,7 @@ class LinkCommand extends Command
         $this->addOption(
             'only-installed',
             null,
-            InputOption::VALUE_NEGATABLE,
+            InputOption::VALUE_NONE,
             'Link only installed packages',
         );
     }

--- a/tests/Unit/LinkManagerTest.php
+++ b/tests/Unit/LinkManagerTest.php
@@ -27,6 +27,7 @@ use ComposerLink\LinkManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+
 use function React\Promise\resolve;
 
 class LinkManagerTest extends TestCase


### PR DESCRIPTION
`InputOption::VALUE_NEGATABLE` Is not yet supported in composer 2.0, furthermore it isn't required in our case. 