### PR TITLE
PHP 8.4 compatibility

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -41,7 +41,7 @@ class Plugin implements PluginInterface, Capable, EventSubscriberInterface
     protected Composer $composer;
 
     public function __construct(
-        ComposerFileSystem $filesystem = null,
+        ?ComposerFileSystem $filesystem = null,
         protected ?LinkPackages $linkPackages = null,
         protected ?RepositoryFactory $repositoryFactory = null
     ) {


### PR DESCRIPTION
Deprecation Notice: ComposerLink\Plugin::__construct(): Implicitly marking parameter $filesystem as nullable is deprecated, the explicit nullable type must be used instead in vendor/sandersander/composer-link/src/Plugin.php:47