### PR TITLE
Allow linking multiple packages in a single command

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ it to the absolute path.
 ```
 composer link ../path/to/package
 composer global link ../path/to/package
+composer link ../path/to/package-one ../path/to/package-two
 ```
 
 It's also possible to use a wildcard in your path, note that this will install all packages found in the directory `../packages`

--- a/src/Commands/LinkCommand.php
+++ b/src/Commands/LinkCommand.php
@@ -28,7 +28,7 @@ class LinkCommand extends Command
     {
         $this->setName('link');
         $this->setDescription('Link a package to a local directory');
-        $this->addArgument('path', InputArgument::REQUIRED, 'The path of the package');
+        $this->addArgument('path', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'The path(s) of the package(s)');
         $this->addOption(
             'without-dependencies',
             null,
@@ -56,11 +56,15 @@ class LinkCommand extends Command
     {
         /** @var bool $onlyInstalled */
         $onlyInstalled = $input->getOption('only-installed');
-        /** @var non-empty-string $pathArgument */
-        $pathArgument = $input->getArgument('path');
-        $paths = $this->getPaths($pathArgument);
+        /** @var non-empty-string[] $pathArguments */
+        $pathArguments = $input->getArgument('path');
         $manager = $this->plugin->getLinkManager();
         $added = [];
+
+        $paths = [];
+        foreach ($pathArguments as $pathArgument) {
+            $paths = array_merge($paths, $this->getPaths($pathArgument));
+        }
 
         foreach ($paths as $path) {
             $package = $this->getPackage($path, $output);

--- a/tests/Unit/Commands/LinkCommandTest.php
+++ b/tests/Unit/Commands/LinkCommandTest.php
@@ -83,6 +83,18 @@ class LinkCommandTest extends TestCase
         static::assertSame(0, $this->application->run($input, $this->output));
     }
 
+    public function test_link_command_multiple_paths(): void
+    {
+        $this->packageFactory->expects(static::exactly(2))
+            ->method('fromPath');
+
+        $this->linkManager->expects(static::exactly(2))->method('add');
+        $this->linkManager->expects(static::once())->method('linkPackages');
+
+        $input = new StringInput('link /test-path-one /test-path-two');
+        static::assertSame(0, $this->application->run($input, $this->output));
+    }
+
     public function test_only_installed_when_not_installed(): void
     {
         $this->packageFactory->expects(static::once())


### PR DESCRIPTION
Built for a use case where one directory contains many packages, but you would like to link only some of them, in one command instead of 1-by-1 (which causes much longer process).

The `link` command accepted a single `path` argument, so linking several local packages meant running `composer link` once per package - each a full install pass. Make `path` variadic (IS_ARRAY | REQUIRED) and gather the resolved paths from every argument before linking. The existing loop already accumulates packages and calls linkPackages() once at the end, so N packages now link in a single pass.

Backwards compatible: a single path still works, wildcards still work, and wildcards can be mixed with explicit paths. The --without-dependencies, --no-dev and --only-installed options apply across all linked packages.